### PR TITLE
Target ES5 for older browser compatbility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "noImplicitAny": true,
     "removeComments": false,
     "suppressImplicitAnyIndexErrors": true,
-    "target": "es2020",
+    "target": "es5",
     "outDir": "dist",
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
First of all, thanks for bringing this module back from the dead!

We're using cbor-js from our web frontend, and we still need to support IE11, so I'm hoping to add support for ES5 targets in the published version.

I don't think this PR quite fills all the requirements for IE11 yet – I think some polyfills are also needed for `Object.is` and `SharedArrayBuffer`. I'm not overly familiar with typescript so not sure whether these should be supplied by this module, as external, or if it's something typescript can do by itself.