### PR TITLE
feat: Release 1.0.0 (attempt 2)

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -8,7 +8,7 @@ on:
       - 'src/**/*.ts'
       - 'mod.ts'
       - 'polyfill.ts'
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ sauce_connect.log
 debug.log
 **/debug.log
 deno.lock
+.DS_Store

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/hook.sh"
 
+deno task clean
 WEB_FILES=$(deno task --quiet build:web)
 if [ -n "$WEB_FILES" ]; then
   echo "generated web, adding files $WEB_FILES"

--- a/polyfill.ts
+++ b/polyfill.ts
@@ -11,11 +11,15 @@ declare global {
   var window: Window & typeof globalThis;
 }
 
-// dnt-shim-ignore
-if (typeof window === "object") {
+export function polyfill() {
   // dnt-shim-ignore
-  window.CBOR = CBORImpl;
-} else {
-  // dnt-shim-ignore
-  (globalThis as any).CBOR = CBORImpl;
+  if (typeof window === "object") {
+    // dnt-shim-ignore
+    window.CBOR = CBORImpl;
+  } else {
+    // dnt-shim-ignore
+    (globalThis as any).CBOR = CBORImpl;
+  }
 }
+
+polyfill();

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=aaronhuggins_cbor-redux
 sonar.organization=aaronhuggins
 sonar.source=src/**,mod.ts,polyfill.ts
-sonar.exclusions=scripts/**,src/testcases.ts,src/*_test.ts,mod.js,polyfill.js
+sonar.exclusions=scripts/**,src/testcases.ts,src/*_test.ts,web/**
 sonar.typescript.tsconfigPath=.sonarcloud.ts.json
 sonar.javascript.lcov.reportPaths=coverage/report.lcov
 sonar.pullrequest.provider=GitHub

--- a/src/CBOR_test.ts
+++ b/src/CBOR_test.ts
@@ -363,17 +363,25 @@ describe("CBOR", () => {
   });
 
   it("Polyfill adds CBOR to global scope", async () => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: undefined,
+    });
     const { polyfill } = await import(polyfillFile);
 
     await polyfill();
 
     strictEqual((globalThis as any).CBOR.decode.name, decode.name);
-    if (typeof (globalThis as any).window === "undefined") {
-      (globalThis as any).window = {} as any;
-      await polyfill();
-
-      strictEqual((globalThis as any).window.CBOR.decode.name, decode.name);
-    }
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: globalThis,
+    });
+    await polyfill();
+    strictEqual((globalThis as any).window.CBOR.decode.name, decode.name);
   });
 });
 

--- a/web/polyfill.js
+++ b/web/polyfill.js
@@ -777,10 +777,15 @@
     encode,
     binarify,
   };
-  if (typeof window === "object") {
-    window.CBOR = mod;
-  } else {
-    globalThis.CBOR = mod;
+  function polyfill() {
+    if (typeof window === "object") {
+      window.CBOR = mod;
+    } else {
+      globalThis.CBOR = mod;
+    }
   }
-  return {};
+  polyfill();
+  return {
+    polyfill: polyfill,
+  };
 })();


### PR DESCRIPTION
Second attempt at release.
Major version change, with definitely breaking changes!

- Redesigned API to align with the `JSON` API in ECMAScript
  - Dropped support in the decoder for `taggedValue` and `simpleValue` callbacks
  - `encode` now takes an optional `replacer` function argument to align with `JSON.stringify`
  - `decode` now takes an optional `reviver` function argument to align with `JSON.parse`
  - `decode` not takes an optional object to set `mode` and `dictionary` behaviors
  - Aliases of `parse` for `decode` and `binarify` for `encode` are now exported
  - Added `Sequence` class for encoding and decoding CBOR Sequences
  - Improved `TaggedValue` to accept `number` or `bigint` tags
  - Improved `SimpleValue` for use as a round-trip encode/decode mechanism
- Updates to decode and encode algorithms to conform very closely to RFC 8949, the latest CBOR revision
- Adds lots of other RFCs
  - Typed Arrays (RFC 8746)
  - CBOR Sequences (RFC 8742)
  - Strictness (required for COSE RFC 8152)
- Support for `bigint`; applications *will* now get `bigint` for integers outside the ECMAScript `number` safe range
- Support for `Map`; applications may use Map to encode and decode non-string keys
- Refactored code to target Deno
- Code is transpiled for Node.js using both ES Modules and CommonJS